### PR TITLE
release(v0.1.0-alpha.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+## [ 0.1.0-alpha.0](https://github.com///releases/tag/v0.1.0-alpha.0) (2025-11-05)
+
+Welcome to the v0.1.0-alpha.0 release of !
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com///issues.
+
+### Contributors
+
+* Spencer Smith
+
+### Changes
+<details><summary>1 commit</summary>
+<p>
+
+* [`45ade1c`](https://github.com///commit/45ade1ca017bf37438ed07d793a5ca5204d92ef6) feat: initial commit of working vsphere provider
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+


### PR DESCRIPTION
This is the official v0.1.0-alpha.0 release.