### PR TITLE
fix: improve error handling and add config validation

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -4,6 +4,8 @@
 
 package config
 
+import "fmt"
+
 // Config describes vsphere provider configuration.
 type Config struct {
 	VSphere VSphereConfig `yaml:"vsphere"`
@@ -14,4 +16,21 @@ type VSphereConfig struct {
 	User               string `yaml:"user"`
 	Password           string `yaml:"password"`
 	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+}
+
+// Validate checks if the configuration is valid.
+func (c *Config) Validate() error {
+	if c.VSphere.URI == "" {
+		return fmt.Errorf("vsphere.uri is required")
+	}
+
+	if c.VSphere.User == "" {
+		return fmt.Errorf("vsphere.user is required")
+	}
+
+	if c.VSphere.Password == "" {
+		return fmt.Errorf("vsphere.password is required")
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Fix error wrapping to include underlying errors with %w
- Add Validate() method to Config struct for required fields
- Add config validation call after decoding YAML
- Add defer vsphereClient.Logout() for proper cleanup
- Add explicit session check to catch authentication failures immediately

Tested and verified on remote system:
- Clear error messages for missing config fields
- Immediate authentication failure detection for wrong credentials
- Proper vSphere session cleanup on shutdown