### PR TITLE
feat: add optional folder parameter for VM placement

### DIFF
--- a/cmd/omni-infra-provider-vsphere/data/schema.json
+++ b/cmd/omni-infra-provider-vsphere/data/schema.json
@@ -34,6 +34,10 @@
     "template": {
       "type": "string",
       "description": "VM template name to clone from"
+    },
+    "folder": {
+      "type": "string",
+      "description": "VM folder path (optional, defaults to datacenter VM folder)"
     }
   },
   "required": [

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -11,6 +11,7 @@ type Data struct {
 	Datastore    string `yaml:"datastore"`
 	Network      string `yaml:"network"`
 	Template     string `yaml:"template"`  // VM template name to clone from
+	Folder       string `yaml:"folder"`    // VM folder path (optional)
 	DiskSize     uint64 `yaml:"disk_size"` // GiB
 	CPU          uint   `yaml:"cpu"`
 	Memory       uint   `yaml:"memory"` // MiB

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -236,10 +236,20 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 
 				finder.SetDatacenter(dc)
 
-				// Find the folder where VMs will be created (default to VM folder in datacenter)
-				folder, err := finder.DefaultFolder(ctx)
-				if err != nil {
-					return provision.NewRetryErrorf(time.Second*10, "failed to find VM folder: %w", err)
+				// Find the folder where VMs will be created
+				var folder *object.Folder
+				if data.Folder != "" {
+					// Use specified folder
+					folder, err = finder.Folder(ctx, data.Folder)
+					if err != nil {
+						return provision.NewRetryErrorf(time.Second*10, "failed to find folder %q: %w", data.Folder, err)
+					}
+				} else {
+					// Default to datacenter VM folder
+					folder, err = finder.DefaultFolder(ctx)
+					if err != nil {
+						return provision.NewRetryErrorf(time.Second*10, "failed to find default VM folder: %w", err)
+					}
 				}
 
 				// Find the resource pool


### PR DESCRIPTION
- Add optional 'folder' parameter to schema
- Support custom VM folder placement in vSphere
- Default to datacenter VM folder if not specified

This allows users to organize VMs in specific folders within vSphere for better management and organization.