### PR TITLE
feat(provider): apply optional vSphere storage policy (SPBM) to VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ See [test/](./test/) for some examples, but generally:
 - Create a machine class with `omnictl apply -f machineclass.yaml`
 - Create a cluster that uses the machine class with `omnictl cluster template sync -f cluster-template.yaml`
 
+### Machine class provider data
+
+The `providerdata` block of the machine class accepts the following fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `datacenter` | yes | vSphere datacenter name |
+| `resource_pool` | yes | Resource pool to place the VM in |
+| `datastore` | yes | Datastore to clone the VM onto |
+| `network` | yes | Network to attach the VM's adapter to |
+| `template` | yes | Name of the OVA template to clone from |
+| `cpu` | yes | Number of vCPUs |
+| `memory` | yes | Memory in MB |
+| `disk_size` | yes | Boot disk size in GB |
+| `folder` | no | VM folder path |
+| `storage_policy` | no | Name of a vSphere Storage Policy (SPBM) applied to the VM home and disks; the datastore default policy is used when omitted |
+| `ca_cert` | no | PEM-encoded CA certificate to add to the node's trusted roots |
+
+When `storage_policy` is set, the named policy is resolved against vCenter and applied to both the VM home and every disk during the clone.
+This lets you, for example, give control plane (etcd) disks a Storage Policy with a higher Storage I/O Control share or reservation than worker disks.
+Provisioning fails with a clear error if the named policy does not exist.
+
 ## Development
 
 See `make help` for general build info.

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -9,11 +9,14 @@ type Data struct {
 	Datacenter   string `yaml:"datacenter"`
 	ResourcePool string `yaml:"resource_pool"`
 	Datastore    string `yaml:"datastore"`
-	Network      string `yaml:"network"`
-	Template     string `yaml:"template"`  // VM template name to clone from
-	Folder       string `yaml:"folder"`    // VM folder path (optional)
-	CACert       string `yaml:"ca_cert"`   // PEM-encoded CA certificate (optional)
-	DiskSize     uint64 `yaml:"disk_size"` // GiB
-	CPU          uint   `yaml:"cpu"`
-	Memory       uint   `yaml:"memory"` // MiB
+	// StoragePolicy is the name of a vSphere Storage Policy (SPBM) to apply to the
+	// cloned VM (home and disks). Optional; when empty the datastore default policy is used.
+	StoragePolicy string `yaml:"storage_policy"`
+	Network       string `yaml:"network"`
+	Template      string `yaml:"template"`  // VM template name to clone from
+	Folder        string `yaml:"folder"`    // VM folder path (optional)
+	CACert        string `yaml:"ca_cert"`   // PEM-encoded CA certificate (optional)
+	DiskSize      uint64 `yaml:"disk_size"` // GiB
+	CPU           uint   `yaml:"cpu"`
+	Memory        uint   `yaml:"memory"` // MiB
 }

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -22,6 +22,8 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/pbm"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"go.uber.org/zap"
 
@@ -217,6 +219,61 @@ func normalizePEMCert(cert string) string {
 	return out.String()
 }
 
+// resolveStoragePolicyID looks up a vSphere Storage Policy (SPBM) by name and
+// returns its profile ID, suitable for a VirtualMachineDefinedProfileSpec.
+func (p *Provisioner) resolveStoragePolicyID(ctx context.Context, name string) (string, error) {
+	pbmClient, err := pbm.NewClient(ctx, p.vsphereClient.Client)
+	if err != nil {
+		return "", fmt.Errorf("failed to create PBM client: %w", err)
+	}
+
+	profiles, err := pbmClient.ProfileMap(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to load storage policy profiles: %w", err)
+	}
+
+	profile, ok := profiles.Name[name]
+	if !ok {
+		return "", fmt.Errorf("storage policy %q not found", name)
+	}
+
+	return profile.GetPbmProfile().ProfileId.UniqueId, nil
+}
+
+// diskProfileLocators reads the template's virtual disks and returns relocate
+// disk locators that apply the given storage profile to each disk during a clone.
+// The home-level VirtualMachineRelocateSpec.Profile does NOT cover the VMDKs, so
+// per-disk locators are required for the storage policy to land on the disks.
+func diskProfileLocators(
+	ctx context.Context,
+	template *object.VirtualMachine,
+	datastoreRef types.ManagedObjectReference,
+	profile []types.BaseVirtualMachineProfileSpec,
+) ([]types.VirtualMachineRelocateSpecDiskLocator, error) {
+	var templateMo mo.VirtualMachine
+	if err := template.Properties(ctx, template.Reference(), []string{"config.hardware.device"}, &templateMo); err != nil {
+		return nil, fmt.Errorf("failed to read template devices: %w", err)
+	}
+
+	if templateMo.Config == nil {
+		return nil, fmt.Errorf("template has no hardware configuration available")
+	}
+
+	var locators []types.VirtualMachineRelocateSpecDiskLocator
+
+	for _, dev := range templateMo.Config.Hardware.Device {
+		if disk, ok := dev.(*types.VirtualDisk); ok {
+			locators = append(locators, types.VirtualMachineRelocateSpecDiskLocator{
+				DiskId:    disk.Key,
+				Datastore: datastoreRef,
+				Profile:   profile,
+			})
+		}
+	}
+
+	return locators, nil
+}
+
 // configureNetwork configures the VM's network adapter to use the specified network.
 func configureNetwork(ctx context.Context, finder *find.Finder, vm *object.VirtualMachine, networkName string) error {
 	if networkName == "" {
@@ -320,6 +377,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					zap.Uint("cpu", data.CPU),
 					zap.Uint("memory", data.Memory),
 					zap.Uint64("disk_size", data.DiskSize),
+					zap.String("storage_policy", data.StoragePolicy),
 					zap.Bool("ca_cert_set", data.CACert != ""),
 				)
 
@@ -423,11 +481,44 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 
 				combinedConfigB64 := base64.StdEncoding.EncodeToString(combinedConfig.Bytes())
 
+				// Resolve the optional storage policy (SPBM). When set, it is applied to
+				// both the VM home (Location.Profile) and every disk (Location.Disk), as
+				// the home profile alone does not cover the VMDKs during a clone.
+				var (
+					profileSpecs []types.BaseVirtualMachineProfileSpec
+					diskLocators []types.VirtualMachineRelocateSpecDiskLocator
+				)
+
+				if data.StoragePolicy != "" {
+					profileID, profileErr := p.resolveStoragePolicyID(ctx, data.StoragePolicy)
+					if profileErr != nil {
+						return provision.NewRetryErrorf(time.Second*10, "failed to resolve storage policy %q: %w", data.StoragePolicy, profileErr)
+					}
+
+					logger.Info(
+						"applying storage policy",
+						zap.String("name", vmName),
+						zap.String("storage_policy", data.StoragePolicy),
+						zap.String("profile_id", profileID),
+					)
+
+					profileSpecs = []types.BaseVirtualMachineProfileSpec{
+						&types.VirtualMachineDefinedProfileSpec{ProfileId: profileID},
+					}
+
+					diskLocators, err = diskProfileLocators(ctx, template, datastoreRef, profileSpecs)
+					if err != nil {
+						return provision.NewRetryErrorf(time.Second*10, "failed to build disk profile locators: %w", err)
+					}
+				}
+
 				// Clone the VM from template
 				cloneSpec := types.VirtualMachineCloneSpec{
 					Location: types.VirtualMachineRelocateSpec{
 						Pool:      &resourcePoolRef,
 						Datastore: &datastoreRef,
+						Profile:   profileSpecs,
+						Disk:      diskLocators,
 					},
 					Config: &types.VirtualMachineConfigSpec{
 						NumCPUs:  int32(data.CPU),

--- a/test/machineclass.yaml
+++ b/test/machineclass.yaml
@@ -14,6 +14,11 @@ spec:
       datacenter: "Datacenter"
       resource_pool: "pool1"
       template: "talos-template"
+      # storage_policy is optional. Name of a vSphere Storage Policy (SPBM) to
+      # apply to the VM home and its disks. When omitted, the datastore default
+      # policy is used. Useful e.g. to give control plane (etcd) disks a higher
+      # Storage I/O Control share/reservation than worker disks.
+      storage_policy: "my-storage-policy"
       # folder is optional.
       folder: "test"
       # ca_cert is optional.


### PR DESCRIPTION
## What

Adds an optional `storage_policy` field to the machine class provider data. When set, the named vSphere Storage Policy (SPBM) is resolved against vCenter and applied to the provisioned VM during the clone — on both the VM home and every disk.

## Why

There is currently no way to control the SPBM policy of provisioned VMs; they inherit the datastore default. This makes it impossible to differentiate storage QoS by role — for example giving control plane (etcd) disks a higher Storage I/O Control share/reservation than worker disks on a shared datastore. With this field that becomes a one-line addition to the machine class.

## Implementation notes

- New optional `storage_policy` field in the provider `Data` struct.
- `resolveStoragePolicyID` looks the policy up by name via the PBM API and returns its profile ID.
- The home-level `VirtualMachineRelocateSpec.Profile` only covers the VM home directory, **not** the VMDKs. The profile is therefore also applied per-disk through `VirtualMachineRelocateSpec.Disk` locators built from the template's disks (`diskProfileLocators`). Without this the policy silently fails to land on the data disks.

## Backwards compatibility

Fully backwards compatible. When `storage_policy` is empty the clone spec is unchanged (`Profile`/`Disk` stay nil) and the datastore default policy is used.

## Testing

Verified against a live vCenter (VMFS datastore):

| scenario | result |
|---|---|
| no `storage_policy` | VM clones as before; no profile on home/disk |
| custom policy name | resolved and applied to the disk |
| built-in policy name (e.g. `vSAN Default Storage Policy`) | resolved and applied to the disk |
| unknown policy name | resolution error, no VM created |

`go build`, `go vet` and `gofmt` are clean. golangci-lint could not be run locally — no release is yet built with the go 1.26.2 toolchain targeted by `go.mod` — so it is left to CI.
