### PR TITLE
feat(provider): add cluster_folder option to group VMs per cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,18 @@ The `providerdata` block of the machine class accepts the following fields:
 | `memory` | yes | Memory in MB |
 | `disk_size` | yes | Boot disk size in GB |
 | `folder` | no | VM folder path |
+| `cluster_folder` | no | When `true`, VMs are placed in a subfolder named after the cluster, created automatically under `folder` (or the datacenter VM folder) |
 | `storage_policy` | no | Name of a vSphere Storage Policy (SPBM) applied to the VM home and disks; the datastore default policy is used when omitted |
 | `ca_cert` | no | PEM-encoded CA certificate to add to the node's trusted roots |
 
 When `storage_policy` is set, the named policy is resolved against vCenter and applied to both the VM home and every disk during the clone.
 This lets you, for example, give control plane (etcd) disks a Storage Policy with a higher Storage I/O Control share or reservation than worker disks.
 Provisioning fails with a clear error if the named policy does not exist.
+
+When `cluster_folder` is set to `true`, the provider creates (if needed) a VM folder for each cluster and clones the VMs into it.
+The folder name is derived from the Omni machine set backing the request: the default `-control-planes` and `-workers` suffixes are stripped, so both machine sets of a cluster share one folder named after the cluster.
+The exact cluster name is not available to infrastructure providers at provision time, so for custom-named worker machine sets the folder is named after the full machine set (e.g. `mycluster-storage-nodes`).
+Folders are not removed on deprovision.
 
 ## Development
 

--- a/cmd/omni-infra-provider-vsphere/data/schema.json
+++ b/cmd/omni-infra-provider-vsphere/data/schema.json
@@ -39,6 +39,10 @@
       "type": "string",
       "description": "VM folder path (optional, defaults to datacenter VM folder)"
     },
+    "cluster_folder": {
+      "type": "boolean",
+      "description": "Place VMs in a subfolder named after the cluster (best-effort, derived from the machine set name), created automatically under the folder above (or the datacenter VM folder)"
+    },
     "ca_cert": {
       "type": "string",
       "description": "PEM-encoded CA certificate(s) to trust on the machine. Provide the full certificate block including BEGIN/END lines. Multiple certificates can be concatenated."

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -13,8 +13,14 @@ type Data struct {
 	// cloned VM (home and disks). Optional; when empty the datastore default policy is used.
 	StoragePolicy string `yaml:"storage_policy"`
 	Network       string `yaml:"network"`
-	Template      string `yaml:"template"`  // VM template name to clone from
-	Folder        string `yaml:"folder"`    // VM folder path (optional)
+	Template      string `yaml:"template"` // VM template name to clone from
+	Folder        string `yaml:"folder"`   // VM folder path (optional)
+	// ClusterFolder, when true, places the VM in a subfolder (under Folder, or the
+	// datacenter VM folder) named after the cluster. The name is best-effort: it is
+	// derived from the Omni machine request set ID by stripping the default
+	// "-control-planes"/"-workers" machine set suffixes; custom-named machine sets
+	// get a folder named after the full machine set ID. Missing folders are created.
+	ClusterFolder bool   `yaml:"cluster_folder"`
 	CACert        string `yaml:"ca_cert"`   // PEM-encoded CA certificate (optional)
 	DiskSize      uint64 `yaml:"disk_size"` // GiB
 	CPU           uint   `yaml:"cpu"`

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -13,16 +13,16 @@ type Data struct {
 	// cloned VM (home and disks). Optional; when empty the datastore default policy is used.
 	StoragePolicy string `yaml:"storage_policy"`
 	Network       string `yaml:"network"`
-	Template      string `yaml:"template"` // VM template name to clone from
-	Folder        string `yaml:"folder"`   // VM folder path (optional)
+	Template      string `yaml:"template"`  // VM template name to clone from
+	Folder        string `yaml:"folder"`    // VM folder path (optional)
+	CACert        string `yaml:"ca_cert"`   // PEM-encoded CA certificate (optional)
+	DiskSize      uint64 `yaml:"disk_size"` // GiB
+	CPU           uint   `yaml:"cpu"`
+	Memory        uint   `yaml:"memory"` // MiB
 	// ClusterFolder, when true, places the VM in a subfolder (under Folder, or the
 	// datacenter VM folder) named after the cluster. The name is best-effort: it is
 	// derived from the Omni machine request set ID by stripping the default
 	// "-control-planes"/"-workers" machine set suffixes; custom-named machine sets
 	// get a folder named after the full machine set ID. Missing folders are created.
-	ClusterFolder bool   `yaml:"cluster_folder"`
-	CACert        string `yaml:"ca_cert"`   // PEM-encoded CA certificate (optional)
-	DiskSize      uint64 `yaml:"disk_size"` // GiB
-	CPU           uint   `yaml:"cpu"`
-	Memory        uint   `yaml:"memory"` // MiB
+	ClusterFolder bool `yaml:"cluster_folder"`
 }

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -12,14 +12,17 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
 	"github.com/siderolabs/omni/client/pkg/infra/provision"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/generate/stdpatches"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/fault"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/pbm"
@@ -274,6 +277,51 @@ func diskProfileLocators(
 	return locators, nil
 }
 
+// clusterFolderName derives a best-effort cluster name from an Omni machine
+// request set ID. The machine request set ID equals the machine set ID
+// ("<cluster>-<machine set suffix>"); the default control plane and worker
+// suffixes are stripped to recover the cluster name. Custom-named machine sets
+// keep the full ID, as the cluster name cannot be reliably separated from it.
+func clusterFolderName(requestSetID string) string {
+	for _, suffix := range []string{omni.ControlPlanesIDSuffix, omni.DefaultWorkersIDSuffix} {
+		if cluster, ok := strings.CutSuffix(requestSetID, "-"+suffix); ok && cluster != "" {
+			return cluster
+		}
+	}
+
+	return requestSetID
+}
+
+// ensureSubfolder returns the child folder of parent with the given name,
+// creating it when it does not exist. A creation race between concurrently
+// provisioned machines of the same cluster is resolved by re-finding the folder.
+func ensureSubfolder(ctx context.Context, finder *find.Finder, parent *object.Folder, name string) (*object.Folder, error) {
+	childPath := path.Join(parent.InventoryPath, name)
+
+	sub, err := finder.Folder(ctx, childPath)
+	if err == nil {
+		return sub, nil
+	}
+
+	var notFoundErr *find.NotFoundError
+	if !errors.As(err, &notFoundErr) {
+		return nil, fmt.Errorf("failed to look up folder %q: %w", childPath, err)
+	}
+
+	sub, err = parent.CreateFolder(ctx, name)
+	if err != nil {
+		if fault.Is(err, &types.DuplicateName{}) {
+			return finder.Folder(ctx, childPath)
+		}
+
+		return nil, fmt.Errorf("failed to create folder %q: %w", childPath, err)
+	}
+
+	sub.SetInventoryPath(childPath)
+
+	return sub, nil
+}
+
 // configureNetwork configures the VM's network adapter to use the specified network.
 func configureNetwork(ctx context.Context, finder *find.Finder, vm *object.VirtualMachine, networkName string) error {
 	if networkName == "" {
@@ -378,6 +426,7 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					zap.Uint("memory", data.Memory),
 					zap.Uint64("disk_size", data.DiskSize),
 					zap.String("storage_policy", data.StoragePolicy),
+					zap.Bool("cluster_folder", data.ClusterFolder),
 					zap.Bool("ca_cert_set", data.CACert != ""),
 				)
 
@@ -405,6 +454,23 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					folder, err = finder.DefaultFolder(ctx)
 					if err != nil {
 						return provision.NewRetryErrorf(time.Second*10, "failed to find default VM folder: %w", err)
+					}
+				}
+
+				// Optionally place the VM in a per-cluster subfolder, creating it if needed.
+				if data.ClusterFolder {
+					requestSetID, ok := pctx.GetMachineRequestSetID()
+					if !ok {
+						return fmt.Errorf("cluster_folder is enabled, but the machine request has no machine request set label")
+					}
+
+					folderName := clusterFolderName(requestSetID)
+
+					logger.Info("using cluster folder", zap.String("name", vmName), zap.String("cluster_folder", folderName))
+
+					folder, err = ensureSubfolder(ctx, finder, folder, folderName)
+					if err != nil {
+						return provision.NewRetryErrorf(time.Second*10, "failed to ensure cluster folder %q: %w", folderName, err)
 					}
 				}
 

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import "testing"
+
+func TestClusterFolderName(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		requestSetID string
+		expected     string
+	}{
+		{requestSetID: "prod-control-planes", expected: "prod"},
+		{requestSetID: "prod-workers", expected: "prod"},
+		{requestSetID: "my-cluster-control-planes", expected: "my-cluster"},
+		{requestSetID: "my-cluster-workers", expected: "my-cluster"},
+		// Custom-named machine sets keep the full ID.
+		{requestSetID: "prod-storage-nodes", expected: "prod-storage-nodes"},
+		// Degenerate IDs are kept as-is rather than reduced to an empty name.
+		{requestSetID: "-workers", expected: "-workers"},
+		{requestSetID: "workers", expected: "workers"},
+	} {
+		t.Run(test.requestSetID, func(t *testing.T) {
+			t.Parallel()
+
+			if actual := clusterFolderName(test.requestSetID); actual != test.expected {
+				t.Errorf("clusterFolderName(%q) = %q, expected %q", test.requestSetID, actual, test.expected)
+			}
+		})
+	}
+}

--- a/internal/pkg/provider/provision_test.go
+++ b/internal/pkg/provider/provision_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package provider
+package provider //nolint:testpackage // white-box test of the unexported clusterFolderName
 
 import "testing"
 

--- a/test/machineclass.yaml
+++ b/test/machineclass.yaml
@@ -21,6 +21,10 @@ spec:
       storage_policy: "my-storage-policy"
       # folder is optional.
       folder: "test"
+      # cluster_folder is optional. When true, VMs are placed in a subfolder
+      # named after the cluster (best-effort, derived from the machine set
+      # name), created automatically under folder (or the datacenter VM folder).
+      cluster_folder: true
       # ca_cert is optional.
       # Use a YAML literal block scalar. The cert content must be indented
       # 2 spaces deeper than the ca_cert key itself.


### PR DESCRIPTION
## What

Adds an optional `cluster_folder` boolean to the machine class provider data. When enabled, VMs are cloned into a subfolder (under the configured `folder`, or the datacenter VM folder) named after the cluster, so each cluster's VMs are grouped together in the vSphere inventory.

## How

- The folder name is derived from the Omni machine request set ID by stripping the default `-control-planes`/`-workers` machine set suffixes, so both machine sets of a cluster share one folder. Custom-named machine sets fall back to the full machine set ID, since the exact cluster name is not exposed to infra providers at provision time.
- Missing folders are created on demand; a concurrent-create race between machines of the same cluster is resolved by re-finding the folder on a `DuplicateName` fault.
- Folders are not removed on deprovision.

The new field is documented in the README field table, added to the machine-class UI schema (`schema.json`), and covered by a unit test for the name derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)