### PR TITLE
feat(provider): support attaching vCenter tags to provisioned VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The `providerdata` block of the machine class accepts the following fields:
 | `cluster_folder` | no | When `true`, VMs are placed in a subfolder named after the cluster, created automatically under `folder` (or the datacenter VM folder) |
 | `storage_policy` | no | Name of a vSphere Storage Policy (SPBM) applied to the VM home and disks; the datastore default policy is used when omitted |
 | `ca_cert` | no | PEM-encoded CA certificate to add to the node's trusted roots |
+| `tags` | no | List of vCenter tags to attach to the VM; each entry is a tag name, or `category/name` when the tag name is not unique across categories |
 
 When `storage_policy` is set, the named policy is resolved against vCenter and applied to both the VM home and every disk during the clone.
 This lets you, for example, give control plane (etcd) disks a Storage Policy with a higher Storage I/O Control share or reservation than worker disks.
@@ -77,6 +78,12 @@ When `cluster_folder` is set to `true`, the provider creates (if needed) a VM fo
 The folder name is derived from the Omni machine set backing the request: the default `-control-planes` and `-workers` suffixes are stripped, so both machine sets of a cluster share one folder named after the cluster.
 The exact cluster name is not available to infrastructure providers at provision time, so for custom-named worker machine sets the folder is named after the full machine set (e.g. `mycluster-storage-nodes`).
 Folders are not removed on deprovision.
+
+When `tags` is set, each named tag is resolved against vCenter and attached to the VM after cloning, before power-on.
+This lets external tooling that keys off vCenter tags (for example backup software assigning VMs to backup policies) pick up the machines without manual tagging.
+The tags and their categories must already exist in vCenter; the provider does not create them.
+A plain tag name must be unique across categories — use the `category/name` form to disambiguate.
+Provisioning fails with a clear error if a tag cannot be resolved.
 
 ## Development
 

--- a/cmd/omni-infra-provider-vsphere/data/schema.json
+++ b/cmd/omni-infra-provider-vsphere/data/schema.json
@@ -46,6 +46,13 @@
     "ca_cert": {
       "type": "string",
       "description": "PEM-encoded CA certificate(s) to trust on the machine. Provide the full certificate block including BEGIN/END lines. Multiple certificates can be concatenated."
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "vCenter tags to attach to the VM (optional). Each entry is a tag name, or \"category/name\" when the tag name exists in multiple categories. Tags must already exist in vCenter."
     }
   },
   "required": [

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -13,12 +13,16 @@ type Data struct {
 	// cloned VM (home and disks). Optional; when empty the datastore default policy is used.
 	StoragePolicy string `yaml:"storage_policy"`
 	Network       string `yaml:"network"`
-	Template      string `yaml:"template"`  // VM template name to clone from
-	Folder        string `yaml:"folder"`    // VM folder path (optional)
-	CACert        string `yaml:"ca_cert"`   // PEM-encoded CA certificate (optional)
-	DiskSize      uint64 `yaml:"disk_size"` // GiB
-	CPU           uint   `yaml:"cpu"`
-	Memory        uint   `yaml:"memory"` // MiB
+	Template      string `yaml:"template"` // VM template name to clone from
+	Folder        string `yaml:"folder"`   // VM folder path (optional)
+	CACert        string `yaml:"ca_cert"`  // PEM-encoded CA certificate (optional)
+	// Tags lists vCenter tags to attach to the VM after cloning. Each entry is a
+	// tag name, or "category/name" when the tag name is not unique across
+	// categories. All tags (and categories) must already exist in vCenter.
+	Tags     []string `yaml:"tags"`
+	DiskSize uint64   `yaml:"disk_size"` // GiB
+	CPU      uint     `yaml:"cpu"`
+	Memory   uint     `yaml:"memory"` // MiB
 	// ClusterFolder, when true, places the VM in a subfolder (under Folder, or the
 	// datacenter VM folder) named after the cluster. The name is best-effort: it is
 	// derived from the Omni machine request set ID by stripping the default

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -639,6 +639,54 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 			},
 		),
 		provision.NewStep(
+			"attachTags",
+			func(ctx context.Context, logger *zap.Logger, pctx provision.Context[*resources.Machine]) error {
+				// Unmarshal provider-specific configuration
+				var data Data
+				if err := pctx.UnmarshalProviderData(&data); err != nil {
+					return fmt.Errorf("failed to unmarshal provider data: %w", err)
+				}
+
+				if len(data.Tags) == 0 {
+					return nil
+				}
+
+				// Ensure session is active
+				if err := p.ensureSession(ctx); err != nil {
+					return provision.NewRetryErrorf(time.Second*10, "failed to ensure vSphere session: %w", err)
+				}
+
+				vmName := pctx.State.TypedSpec().Value.VmName
+				if vmName == "" {
+					return provision.NewRetryErrorf(time.Second*10, "waiting for VM to be created")
+				}
+
+				finder := find.NewFinder(p.vsphereClient.Client, true)
+
+				// Find the datacenter
+				dc, err := finder.Datacenter(ctx, data.Datacenter)
+				if err != nil {
+					return provision.NewRetryErrorf(time.Second*10, "failed to find datacenter %q: %w", data.Datacenter, err)
+				}
+
+				finder.SetDatacenter(dc)
+
+				// Find the VM
+				vm, err := finder.VirtualMachine(ctx, vmName)
+				if err != nil {
+					return provision.NewRetryErrorf(time.Second*10, "failed to find VM %q: %w", vmName, err)
+				}
+
+				logger.Info("attaching vCenter tags", zap.String("name", vmName), zap.Strings("tags", data.Tags))
+
+				if err := p.attachTags(ctx, vm.Reference(), data.Tags); err != nil {
+					return provision.NewRetryErrorf(time.Second*10, "failed to attach tags to VM %q: %w", vmName, err)
+				}
+
+				return nil
+			},
+		),
+		provision.NewStep(
 			"powerOnVM",
 			func(ctx context.Context, logger *zap.Logger, pctx provision.Context[*resources.Machine]) error {
 				// Ensure session is active

--- a/internal/pkg/provider/tags.go
+++ b/internal/pkg/provider/tags.go
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/mo"
+	"go.uber.org/zap"
+)
+
+// splitTagSpec splits a machine class tag entry into its optional category and
+// tag name parts. The "category/name" form pins the tag to a category; a plain
+// name matches across all categories. The first slash separates the parts, so
+// a tag name may not contain a slash unless a category is given.
+func splitTagSpec(spec string) (category, name string) {
+	if before, after, found := strings.Cut(spec, "/"); found {
+		return before, after
+	}
+
+	return "", spec
+}
+
+// matchTagsByName returns all tags with the given name. A tag name is only
+// unique within its category, so multiple matches are possible.
+func matchTagsByName(allTags []tags.Tag, name string) []tags.Tag {
+	var matches []tags.Tag
+
+	for _, tag := range allTags {
+		if tag.Name == name {
+			matches = append(matches, tag)
+		}
+	}
+
+	return matches
+}
+
+// resolveTagIDs resolves machine class tag specs ("name" or "category/name")
+// to vCenter tag IDs. Plain names must be unambiguous across categories.
+func resolveTagIDs(ctx context.Context, manager *tags.Manager, specs []string) ([]string, error) {
+	ids := make([]string, 0, len(specs))
+
+	var (
+		allTags     []tags.Tag
+		tagsFetched bool
+	)
+
+	for _, spec := range specs {
+		category, name := splitTagSpec(spec)
+
+		if name == "" {
+			return nil, fmt.Errorf("invalid tag %q: empty tag name", spec)
+		}
+
+		if category != "" {
+			cat, err := manager.GetCategory(ctx, category)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find tag category %q: %w", category, err)
+			}
+
+			tag, err := manager.GetTagForCategory(ctx, name, cat.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find tag %q in category %q: %w", name, category, err)
+			}
+
+			ids = append(ids, tag.ID)
+
+			continue
+		}
+
+		if !tagsFetched {
+			var err error
+
+			allTags, err = manager.GetTags(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list tags: %w", err)
+			}
+
+			tagsFetched = true
+		}
+
+		matches := matchTagsByName(allTags, name)
+
+		switch len(matches) {
+		case 0:
+			return nil, fmt.Errorf("tag %q not found", name)
+		case 1:
+			ids = append(ids, matches[0].ID)
+		default:
+			return nil, fmt.Errorf("tag name %q exists in multiple categories, use \"category/name\" to disambiguate", name)
+		}
+	}
+
+	return ids, nil
+}
+
+// attachTags attaches the given machine class tags to the VM. Tags are
+// resolved and attached via the vSphere Automation (REST) API, which uses its
+// own session next to the SOAP one; a fresh session is created per call.
+// All tags are resolved before the first attach, and attaching an already
+// attached tag is a no-op, so the operation is safe to retry.
+func (p *Provisioner) attachTags(ctx context.Context, vmRef mo.Reference, specs []string) error {
+	restClient := rest.NewClient(p.vsphereClient.Client)
+
+	if err := restClient.Login(ctx, p.userInfo); err != nil {
+		return fmt.Errorf("failed to log in to the vSphere automation API: %w", err)
+	}
+
+	defer func() {
+		if err := restClient.Logout(ctx); err != nil {
+			p.logger.Debug("failed to log out of the vSphere automation API", zap.Error(err))
+		}
+	}()
+
+	manager := tags.NewManager(restClient)
+
+	ids, err := resolveTagIDs(ctx, manager, specs)
+	if err != nil {
+		return err
+	}
+
+	for i, id := range ids {
+		if err := manager.AttachTag(ctx, id, vmRef); err != nil {
+			return fmt.Errorf("failed to attach tag %q: %w", specs[i], err)
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/provider/tags_test.go
+++ b/internal/pkg/provider/tags_test.go
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider //nolint:testpackage // white-box test of unexported splitTagSpec and matchTagsByName
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vapi/tags"
+)
+
+func TestSplitTagSpec(t *testing.T) {
+	for _, test := range []struct {
+		spec     string
+		category string
+		name     string
+	}{
+		{spec: "backup-daily", category: "", name: "backup-daily"},
+		{spec: "backup-policy/daily", category: "backup-policy", name: "daily"},
+		{spec: "env/prod/extra", category: "env", name: "prod/extra"},
+		{spec: "/name-only", category: "", name: "name-only"},
+		{spec: "category-only/", category: "category-only", name: ""},
+		{spec: "", category: "", name: ""},
+	} {
+		t.Run(test.spec, func(t *testing.T) {
+			category, name := splitTagSpec(test.spec)
+
+			if category != test.category || name != test.name {
+				t.Errorf("splitTagSpec(%q) = (%q, %q), expected (%q, %q)", test.spec, category, name, test.category, test.name)
+			}
+		})
+	}
+}
+
+func TestMatchTagsByName(t *testing.T) {
+	allTags := []tags.Tag{
+		{ID: "urn:1", Name: "daily", CategoryID: "backup-policy"},
+		{ID: "urn:2", Name: "prod", CategoryID: "env"},
+		{ID: "urn:3", Name: "daily", CategoryID: "snapshots"},
+	}
+
+	for _, test := range []struct {
+		name        string
+		expectedIDs []string
+	}{
+		{name: "prod", expectedIDs: []string{"urn:2"}},
+		{name: "daily", expectedIDs: []string{"urn:1", "urn:3"}},
+		{name: "missing", expectedIDs: nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			matches := matchTagsByName(allTags, test.name)
+
+			if len(matches) != len(test.expectedIDs) {
+				t.Fatalf("matchTagsByName(%q) returned %d matches, expected %d", test.name, len(matches), len(test.expectedIDs))
+			}
+
+			for i, match := range matches {
+				if match.ID != test.expectedIDs[i] {
+					t.Errorf("matchTagsByName(%q)[%d] = %q, expected %q", test.name, i, match.ID, test.expectedIDs[i])
+				}
+			}
+		})
+	}
+}

--- a/test/machineclass.yaml
+++ b/test/machineclass.yaml
@@ -25,6 +25,12 @@ spec:
       # named after the cluster (best-effort, derived from the machine set
       # name), created automatically under folder (or the datacenter VM folder).
       cluster_folder: true
+      # tags is optional. vCenter tags to attach to the VM. Each entry is a
+      # tag name, or "category/name" when the tag name exists in multiple
+      # categories. Tags must already exist in vCenter.
+      tags:
+        - "backup-policy/daily"
+        - "environment-prod"
       # ca_cert is optional.
       # Use a YAML literal block scalar. The cert content must be indented
       # 2 spaces deeper than the ca_cert key itself.


### PR DESCRIPTION
Fixes #38

## What

Adds an optional `tags` list to the machine class provider data. When set, the provider attaches the named vCenter tags to the VM after cloning and before power-on, so tag-driven tooling (such as backup software assigning VMs to backup policies) picks the machines up without manual tagging.

## How

- Each entry is a tag name, or `category/name` when the tag name is not unique across categories; ambiguous plain names fail with an error suggesting the `category/name` form.
- Tags are resolved and attached via the vSphere Automation (REST) API (`vapi/rest` + `vapi/tags`), with a session created per invocation next to the existing SOAP session.
- Attaching happens in a dedicated idempotent `attachTags` provisioning step between `createVM` and `powerOnVM`: all tags are resolved before the first attach, and re-attaching an existing association is a no-op, so retries are safe.
- Tags and categories must already exist in vCenter; the provider does not create them, and unresolvable tags fail provisioning with a clear error (matching the `storage_policy` behavior).

The new field is documented in the README field table, added to the machine-class UI schema (`schema.json`) and the example machine class, and the tag-spec parsing/matching helpers are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)