### PR TITLE
feat(provider): deploy from a vSphere Content Library OVF item

### DIFF
--- a/internal/pkg/provider/content_library.go
+++ b/internal/pkg/provider/content_library.go
@@ -1,0 +1,196 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/vcenter"
+	"github.com/vmware/govmomi/vim25/types"
+	"go.uber.org/zap"
+)
+
+// deployFromContentLibrary deploys a VM from a vSphere Content Library OVF item
+// (Data.ContentLibrary / Data.LibraryItem) via the vAPI, as an alternative to
+// cloning an inventory VM Template. It returns the created VM, powered off.
+//
+// Unlike the clone path, the OVF deploy spec cannot carry the Talos machine
+// config (vCenter only honors extra-config keys the OVF pre-declares), so the
+// guestinfo config and the CPU/memory/disk overrides are applied afterward by
+// finalizeVM. Network and, when set, the storage policy are applied here at
+// deploy time. disk.EnableUUID is baked into the Talos vmware OVA already.
+func (p *Provisioner) deployFromContentLibrary(
+	ctx context.Context,
+	finder *find.Finder,
+	data Data,
+	vmName string,
+	resourcePool *object.ResourcePool,
+	folder *object.Folder,
+	datastore *object.Datastore,
+	logger *zap.Logger,
+) (*object.VirtualMachine, error) {
+	// The Content Library deploy uses the vAPI (REST), which needs its own
+	// session alongside the existing vim25/SOAP client.
+	rc := rest.NewClient(p.vsphereClient.Client)
+	if err := rc.Login(ctx, p.userInfo); err != nil {
+		return nil, fmt.Errorf("failed to log in to vAPI REST session: %w", err)
+	}
+
+	defer func() {
+		if err := rc.Logout(ctx); err != nil {
+			logger.Debug("vAPI REST logout failed", zap.Error(err))
+		}
+	}()
+
+	libMgr := library.NewManager(rc)
+
+	lib, err := libMgr.GetLibraryByName(ctx, data.ContentLibrary)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find content library %q: %w", data.ContentLibrary, err)
+	}
+
+	itemIDs, err := libMgr.FindLibraryItems(ctx, library.FindItem{LibraryID: lib.ID, Name: data.LibraryItem})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find library item %q in %q: %w", data.LibraryItem, data.ContentLibrary, err)
+	}
+
+	if len(itemIDs) != 1 {
+		return nil, fmt.Errorf("expected exactly one library item named %q in %q, found %d", data.LibraryItem, data.ContentLibrary, len(itemIDs))
+	}
+
+	itemID := itemIDs[0]
+
+	resourcePoolID := resourcePool.Reference().Value
+
+	deploySpec := vcenter.DeploymentSpec{
+		Name:                vmName,
+		AcceptAllEULA:       true,
+		DefaultDatastoreID:  datastore.Reference().Value,
+		StorageProvisioning: "thin",
+	}
+
+	// Map every network the OVF declares onto the requested network. The OVF
+	// network identifiers are discovered from the deployment filter.
+	if data.Network != "" {
+		network, netErr := finder.Network(ctx, data.Network)
+		if netErr != nil {
+			return nil, fmt.Errorf("failed to find network %q: %w", data.Network, netErr)
+		}
+
+		networkID := network.Reference().Value
+
+		filter, filterErr := vcenter.NewManager(rc).FilterLibraryItem(ctx, itemID, vcenter.FilterRequest{
+			Target: vcenter.Target{ResourcePoolID: resourcePoolID},
+		})
+		if filterErr != nil {
+			return nil, fmt.Errorf("failed to inspect OVF networks for %q: %w", data.LibraryItem, filterErr)
+		}
+
+		for _, ovfNetwork := range filter.Networks {
+			deploySpec.NetworkMappings = append(deploySpec.NetworkMappings, vcenter.NetworkMapping{
+				Key:   ovfNetwork,
+				Value: networkID,
+			})
+		}
+	}
+
+	// Optional storage policy (SPBM). Unlike the clone path, the OVF deploy
+	// spec's storage_profile_id covers the whole deployment (home and disks),
+	// so no per-disk locators are needed here.
+	if data.StoragePolicy != "" {
+		profileID, policyErr := p.resolveStoragePolicyID(ctx, data.StoragePolicy)
+		if policyErr != nil {
+			return nil, fmt.Errorf("failed to resolve storage policy %q: %w", data.StoragePolicy, policyErr)
+		}
+
+		logger.Info(
+			"applying storage policy",
+			zap.String("name", vmName),
+			zap.String("storage_policy", data.StoragePolicy),
+			zap.String("profile_id", profileID),
+		)
+
+		deploySpec.StorageProfileID = profileID
+	}
+
+	deploy := vcenter.Deploy{
+		DeploymentSpec: deploySpec,
+		Target: vcenter.Target{
+			ResourcePoolID: resourcePoolID,
+			FolderID:       folder.Reference().Value,
+		},
+	}
+
+	logger.Info(
+		"deploying VM from content library",
+		zap.String("name", vmName),
+		zap.String("content_library", data.ContentLibrary),
+		zap.String("library_item", data.LibraryItem),
+	)
+
+	ref, err := vcenter.NewManager(rc).DeployLibraryItem(ctx, itemID, deploy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy library item %q: %w", data.LibraryItem, err)
+	}
+
+	if ref == nil {
+		return nil, fmt.Errorf("content library deploy of %q returned no VM reference", data.LibraryItem)
+	}
+
+	return object.NewVirtualMachine(p.vsphereClient.Client, *ref), nil
+}
+
+// finalizeVM applies the settings an OVF deploy does not cover: the Talos
+// machine config (guestinfo), the CPU/memory override, and the disk resize. It
+// mirrors what the clone path bakes into the clone spec, injected here via a
+// post-deploy reconfigure. disk.enableUUID is set as well for parity, though the
+// Talos vmware OVA already bakes it in.
+func (p *Provisioner) finalizeVM(
+	ctx context.Context,
+	vm *object.VirtualMachine,
+	data Data,
+	combinedConfigB64 string,
+	logger *zap.Logger,
+) error {
+	spec := types.VirtualMachineConfigSpec{
+		NumCPUs:  int32(data.CPU),
+		MemoryMB: int64(data.Memory),
+		ExtraConfig: []types.BaseOptionValue{
+			&types.OptionValue{Key: "disk.enableUUID", Value: "TRUE"},
+			&types.OptionValue{Key: "guestinfo.talos.config", Value: combinedConfigB64},
+		},
+	}
+
+	logger.Info(
+		"finalizing VM (config, cpu, memory)",
+		zap.String("name", vm.Name()),
+		zap.Uint("cpu", data.CPU),
+		zap.Uint("memory", data.Memory),
+	)
+
+	task, err := vm.Reconfigure(ctx, spec)
+	if err != nil {
+		return fmt.Errorf("failed to reconfigure VM: %w", err)
+	}
+
+	if err := task.Wait(ctx); err != nil {
+		return fmt.Errorf("VM reconfigure task failed: %w", err)
+	}
+
+	if data.DiskSize > 0 {
+		logger.Info("resizing VM disk", zap.String("name", vm.Name()), zap.Uint64("disk_size_gib", data.DiskSize))
+
+		if err := resizeDisk(ctx, vm, data.DiskSize); err != nil {
+			return fmt.Errorf("failed to resize disk: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/provider/data.go
+++ b/internal/pkg/provider/data.go
@@ -4,6 +4,8 @@
 
 package provider
 
+import "errors"
+
 // Data is the provider custom machine config.
 type Data struct {
 	Datacenter   string `yaml:"datacenter"`
@@ -13,9 +15,14 @@ type Data struct {
 	// cloned VM (home and disks). Optional; when empty the datastore default policy is used.
 	StoragePolicy string `yaml:"storage_policy"`
 	Network       string `yaml:"network"`
-	Template      string `yaml:"template"` // VM template name to clone from
-	Folder        string `yaml:"folder"`   // VM folder path (optional)
-	CACert        string `yaml:"ca_cert"`  // PEM-encoded CA certificate (optional)
+	Template      string `yaml:"template"` // VM template name to clone from (inventory)
+	// ContentLibrary + LibraryItem select a vSphere Content Library OVF item to
+	// deploy from, as an alternative to cloning an inventory Template. Optional;
+	// mutually exclusive with Template. See issue #25.
+	ContentLibrary string `yaml:"content_library"`
+	LibraryItem    string `yaml:"library_item"`
+	Folder         string `yaml:"folder"`  // VM folder path (optional)
+	CACert         string `yaml:"ca_cert"` // PEM-encoded CA certificate (optional)
 	// Tags lists vCenter tags to attach to the VM after cloning. Each entry is a
 	// tag name, or "category/name" when the tag name is not unique across
 	// categories. All tags (and categories) must already exist in vCenter.
@@ -29,4 +36,22 @@ type Data struct {
 	// "-control-planes"/"-workers" machine set suffixes; custom-named machine sets
 	// get a folder named after the full machine set ID. Missing folders are created.
 	ClusterFolder bool `yaml:"cluster_folder"`
+}
+
+// Validate checks that the provider data selects exactly one VM source: an
+// inventory Template, or a Content Library item (ContentLibrary + LibraryItem).
+func (d Data) Validate() error {
+	usingTemplate := d.Template != ""
+	usingLibrary := d.ContentLibrary != "" || d.LibraryItem != ""
+
+	switch {
+	case usingTemplate && usingLibrary:
+		return errors.New("both template and content_library/library_item are set; they are mutually exclusive")
+	case !usingTemplate && !usingLibrary:
+		return errors.New("no VM source set: specify either template, or content_library + library_item")
+	case usingLibrary && (d.ContentLibrary == "" || d.LibraryItem == ""):
+		return errors.New("content_library and library_item must both be set")
+	}
+
+	return nil
 }

--- a/internal/pkg/provider/data_test.go
+++ b/internal/pkg/provider/data_test.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/siderolabs/omni-infra-provider-vsphere/internal/pkg/provider"
+)
+
+func TestDataValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		data    provider.Data
+		wantErr bool
+	}{
+		{"template only", provider.Data{Template: "tmpl"}, false},
+		{"content library only", provider.Data{ContentLibrary: "lib", LibraryItem: "item"}, false},
+		{"both sources set", provider.Data{Template: "tmpl", ContentLibrary: "lib", LibraryItem: "item"}, true},
+		{"no source set", provider.Data{}, true},
+		{"library missing item", provider.Data{ContentLibrary: "lib"}, true},
+		{"library missing library name", provider.Data{LibraryItem: "item"}, true},
+		{"template plus stray library name", provider.Data{Template: "tmpl", ContentLibrary: "lib"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.data.Validate(); (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/pkg/provider/provision.go
+++ b/internal/pkg/provider/provision.go
@@ -413,6 +413,10 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					return fmt.Errorf("failed to unmarshal provider data: %w", err)
 				}
 
+				if err := data.Validate(); err != nil {
+					return fmt.Errorf("invalid provider data: %w", err)
+				}
+
 				vmName := pctx.GetRequestID()
 
 				logger.Info(
@@ -480,12 +484,6 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 					return provision.NewRetryErrorf(time.Second*10, "failed to find resource pool %q: %w", data.ResourcePool, err)
 				}
 
-				// Find the template VM
-				template, err := finder.VirtualMachine(ctx, data.Template)
-				if err != nil {
-					return provision.NewRetryErrorf(time.Second*10, "failed to find template %q: %w", data.Template, err)
-				}
-
 				// Find the datastore
 				datastore, err := finder.Datastore(ctx, data.Datastore)
 				if err != nil {
@@ -546,6 +544,30 @@ func (p *Provisioner) ProvisionSteps() []provision.Step[*resources.Machine] {
 				}
 
 				combinedConfigB64 := base64.StdEncoding.EncodeToString(combinedConfig.Bytes())
+
+				// Content Library deploy path: deploy from the OVF item, then apply the
+				// config/cpu/memory/disk that the OVF deploy spec cannot carry cleanly.
+				if data.LibraryItem != "" {
+					vm, deployErr := p.deployFromContentLibrary(ctx, finder, data, vmName, resourcePool, folder, datastore, logger)
+					if deployErr != nil {
+						return provision.NewRetryErrorf(time.Second*10, "failed to deploy from content library: %w", deployErr)
+					}
+
+					if finalizeErr := p.finalizeVM(ctx, vm, data, combinedConfigB64, logger); finalizeErr != nil {
+						return provision.NewRetryErrorf(time.Second*10, "failed to finalize VM: %w", finalizeErr)
+					}
+
+					pctx.State.TypedSpec().Value.VmName = vmName
+					pctx.State.TypedSpec().Value.Datacenter = data.Datacenter
+
+					return nil
+				}
+
+				// Template clone path: find the inventory template to clone from.
+				template, err := finder.VirtualMachine(ctx, data.Template)
+				if err != nil {
+					return provision.NewRetryErrorf(time.Second*10, "failed to find template %q: %w", data.Template, err)
+				}
 
 				// Resolve the optional storage policy (SPBM). When set, it is applied to
 				// both the VM home (Location.Profile) and every disk (Location.Disk), as


### PR DESCRIPTION
## What

Adds an optional vSphere Content Library OVF item as an alternative VM source to the existing inventory template clone. Two new provider data fields, `content_library` and `library_item`, select a Content Library item to deploy from; they are mutually exclusive with `template` and validated up front (exactly one source must be set). When a library item is given, the provider deploys it via the vAPI `DeployLibraryItem` instead of cloning a template.

## Why

Deploying directly from a Content Library removes the manual "OVA into inventory, convert to template" step: a Talos OVA from Image Factory can be synced into a Content Library and consumed as-is. Requested in #25.

## How

- `content_library.go`:
  - `deployFromContentLibrary` opens a vAPI REST session alongside the existing vim25 client, resolves the library and item by name, discovers the OVF networks with `FilterLibraryItem`, and deploys with `DeployLibraryItem` — mapping the OVF networks onto the requested network and, when set, applying the storage policy at deploy time via `storage_profile_id` (which covers the VM home and its disks, so no per-disk locators are needed here).
  - `finalizeVM` applies what the OVF deploy spec cannot carry: the Talos machine config (`guestinfo.talos.config`), the CPU/memory override, and the disk resize, via a post-deploy reconfigure.
- `provision.go`: `createVM` is restructured so both paths share the config build and target resolution; the library path branches to deploy + finalize. The template clone path is unchanged in behavior.

**On config injection.** The OVF deploy spec cannot carry the Talos config the way the clone path bakes it into the clone spec. vCenter only honors extra-config keys the OVF pre-declares, so `guestinfo.talos.config` passed through `ExtraConfigParams` at deploy time is dropped. The Talos vmware OVA does declare a `talos.config` vApp property, but rather than depend on that path I inject the config through the same post-deploy reconfigure the clone path already uses — one mechanism shared by both. `disk.EnableUUID=true` is already baked into the Talos vmware OVA, so the library path does not set it.

## Backwards compatibility

Fully backwards compatible. With `template` set and the library fields empty, behavior is unchanged.

## Testing

Verified end-to-end against a live vCenter 8 and a self-hosted Omni:

- Provisioned a 1 control-plane + 1 worker cluster from a Content Library OVF item (Talos v1.13.6 vmware OVA). Both nodes were deployed via `DeployLibraryItem`, received the machine config, joined Omni over SideroLink, and the cluster reached healthy on Kubernetes v1.36.2. Deprovision removed the library-deployed VMs the same as cloned ones.
- The existing template clone path was exercised at the same time: a template-based cluster stayed healthy across the provider swap and its machine requests reconciled cleanly on this build.

`go build`, `go vet`, and `go test ./...` are clean on the go 1.26 toolchain. golangci-lint is left to CI, as with the earlier PRs.

Fixes #25.
